### PR TITLE
Send \x08 instead of \x7f when pressing backspace

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/js/app.js
+++ b/js/app.js
@@ -195,6 +195,10 @@ function setupHterm() {
         }],
     ]);
 
+    //Send backspace \x08 instead of delete  (\x7f) when pressing the backspace
+    // key
+    term.prefs_.set('backspace-sends-backspace', true)
+
     // Useful for console debugging.
     window.term_ = term;
 }


### PR DESCRIPTION
By default, hterm sends the ASCII Delete character (\x7f) when hitting the backspace key. This is incompatible with the behavior of the nrf_cli library which only reacts on the backspace key (\x08). The result is that typos when entering stuff in the web-cli cannot be deleted from the command line. With the command below, we instruct hterm to actually emit the \x08 character when backspace is typed.